### PR TITLE
Reuse repository

### DIFF
--- a/example/config.toml
+++ b/example/config.toml
@@ -6,7 +6,6 @@ password = "test"
 [backup.options]
 
 [[backup]]
-name = "s3-backup"
 repository = "opendal:s3"
 password = "test"
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -90,11 +90,10 @@ impl RusticCollector {
                 .options(this.backup.options)
                 .to_backends()
                 .unwrap();
-            let repository = Repository::new(&opts, &backend)
+            Repository::new(&opts, &backend)
                 .expect("cannot create the repository")
                 .open()
-                .expect("cannot open the repository");
-            repository
+                .expect("cannot open the repository")
         })
         .await
         .unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,6 @@ pub(crate) struct Config {
 
 #[derive(Clone, Deserialize, Debug)]
 pub(crate) struct Backup {
-    pub(crate) name: String,
     pub(crate) repository: String,
     pub(crate) password: String,
     pub(crate) options: HashMap<String, String>,


### PR DESCRIPTION
Follows the suggestion in rustic discord [chat](https://discord.com/channels/1101748142694748181/1101748180007264276/1299099223278751764). 

Few changes in PR:
- Preserves `Repository` in `RusticCollector.state`
- Change the data update function to `Repository::update_all_snapshots`. 
- For metrics label `name`, deprecate `backup.name` option in configuration file, and use the internal `Repository.name`. 
