### PR TITLE
refactor: use ArcSwap and remove Mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,12 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "array-init"
@@ -2787,6 +2790,7 @@ dependencies = [
 name = "rustic-exporter"
 version = "0.1.0-rc.8"
 dependencies = [
+ "arc-swap",
  "axum",
  "clap",
  "prometheus-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = "1.0.210"
 tokio = { version = "1.40.0", features = ["full"] }
 toml = "0.8.19"
 regex = "1.11.1"
+arc-swap = "1.8.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -125,14 +125,16 @@ impl RusticCollector {
                 None => return,
             };
 
-            match repo.update_all_snapshots(collector.snapshots.load().to_vec()) {
-                Ok(snapshots) => collector.snapshots.swap(Arc::new(snapshots)),
+            let snapshots_result = repo.update_all_snapshots(collector.snapshots.load().to_vec());
+            match snapshots_result {
+                Ok(snapshots) => {
+                    collector.snapshots.swap(Arc::new(snapshots));
+                }
                 Err(_err) => {
                     error!(
                         "Unable to update snapshot, repository: {}",
                         collector.backup.name
                     );
-                    return;
                 }
             };
         })

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -70,7 +70,7 @@ impl RusticCollector {
         tokio::spawn(async move {
             Self::set_repository(collector_task.clone()).await;
             loop {
-                Self::update_snpashot(collector_task.clone()).await;
+                Self::update_snapshot(collector_task.clone()).await;
                 tokio::time::sleep(Duration::from_secs(interval)).await;
             }
         });
@@ -114,7 +114,7 @@ impl RusticCollector {
         info!("Repository is ready, repository: {}", self.backup.name);
     }
 
-    async fn update_snpashot(self: Arc<Self>) {
+    async fn update_snapshot(self: Arc<Self>) {
         debug!("Updating metrics, repository: {}", self.backup.name);
 
         let collector = self.clone();
@@ -187,7 +187,7 @@ impl Collector for RusticCollector {
             .set(1);
 
         // set snapshot metrics
-        for snapshot in self.snapshots.load().to_vec() {
+        for snapshot in &**self.snapshots.load() {
             let snapshot_info_labels = SnapshotInfoLabels {
                 repo_name: self.backup.name.clone(),
                 repo_id: repo_config.id.to_string(),

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -17,6 +17,7 @@ use tracing::{debug, error, info, warn};
 #[derive(Debug)]
 pub struct RusticCollector {
     backup: Backup,
+    interval: u64,
     repository: ArcSwap<Option<Repository<NoProgressBars, OpenStatus>>>,
     snapshots: ArcSwap<Vec<SnapshotFile>>,
 }
@@ -62,6 +63,7 @@ impl RusticCollector {
     pub fn new(backup: Backup, interval: u64) -> Arc<Self> {
         let collector = Arc::new(Self {
             backup,
+            interval,
             repository: ArcSwap::new(Arc::new(None)),
             snapshots: ArcSwap::new(Arc::new(Vec::new())),
         });
@@ -71,7 +73,7 @@ impl RusticCollector {
             Self::set_repository(collector_task.clone()).await;
             loop {
                 Self::update_snapshot(collector_task.clone()).await;
-                tokio::time::sleep(Duration::from_secs(interval)).await;
+                tokio::time::sleep(Duration::from_secs(collector_task.interval)).await;
             }
         });
         collector


### PR DESCRIPTION
Related issue: https://github.com/timtorChen/rustic-exporter/issues/44

### Main changes

To address the issue that metrics is not able to be read while updating, this PR do the refactor by introducing atomically swap pointer `ArcSwap` and remove the `Mutex` lock. 

- Simplify the structure by integrating `State` into `RusticCollector`.
- Rmove the property `ready`, and determine the repository readiness by not `None`.
- Wrap `ArcSwap` on original repository and snapshots to allow atomic updates.
- Update RusticCollector internal method to use `Arc<RusticCollector>` as the receiver type allowing background tasks safely share ownership.

### Minor
- Rename `update_data` to `update_snapshot` to better reflect the usage.



