### PR TITLE
ci: release binary

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build
-        uses: houseabsolute/actions-rust-cross@v1
+        uses: houseabsolute/actions-rust-cross@a8cc74d61047fa553b4e908b4b10e70029f00ca6 # v1.0.6
         with:
           command: build
           target: ${{ matrix.platform.target }}
@@ -72,14 +72,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: assets-*
           path: ./dist
           merge-multiple: true
 
       - name: Publish
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           generate_release_notes: true

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -8,14 +8,79 @@ on:
       - "v*.*.*-rc*"
 
 jobs:
-  release:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os-name: Linux-x86_64
+            runs-on: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+
+          - os-name: Linux-aarch64
+            runs-on: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+
+          - os-name: macOS-x86_64
+            runs-on: macOS-latest
+            target: x86_64-apple-darwin
+
+          - os-name: macOS-aarch64
+            runs-on: macOS-latest
+            target: aarch64-apple-darwin
+
+          - os-name: Windows-x86_64
+            runs-on: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    name: Build - ${{ matrix.platform.os-name }}
+    runs-on: ${{ matrix.platform.runs-on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Build
+        uses: houseabsolute/actions-rust-cross@v1
+        with:
+          command: build
+          target: ${{ matrix.platform.target }}
+          args: "--release"
+      - name: Compress
+        shell: bash
+        run: | #bash
+          VERSION=${GITHUB_REF#refs/tags/}
+          TARGET=${{ matrix.platform.target }}
+          ASSET="rustic-exporter-$VERSION-$TARGET"
+
+          mkdir -p "$ASSET"
+          if [[ $TARGET == *"windows"* ]]; then
+            cp target/$TARGET/release/rustic-exporter.exe "$ASSET"
+          else
+            cp target/$TARGET/release/rustic-exporter "$ASSET"
+          fi
+
+          tar -czf "${ASSET}.tar.gz" "${ASSET}"
+
+      - name: Collect Artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          path: "*.tar.gz"
+          name: assets-${{ matrix.platform.target }}
+          overwrite: true
+
+  publish:
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Create Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
         with:
-          generate_release_notes: true
+          pattern: assets-*
+          path: ./dist
+          merge-multiple: true
+
+      - name: Publish
+        uses: softprops/action-gh-release@v2
+        with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
+          files: ./dist/*.tar.gz


### PR DESCRIPTION
Related issue: https://github.com/timtorChen/rustic-exporter/issues/46

While push a tag, the workflow will publish target assets:
- x86_64-unknown-linux-musl
- aarch64-unknown-linux-musl
- x86_64-apple-darwin
- aarch64-apple-darwin
- x86_64-pc-windows-msvc