### PR TITLE
feat: add Alpine docker image

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -8,7 +8,7 @@ on:
       - "v*.*.*-rc*"
 
 jobs:
-  docker:
+  docker-distroless:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
@@ -27,7 +27,7 @@ jobs:
           repository=${{ github.repository }}
           echo "lowercase_repository=${repository,,}" >> ${GITHUB_OUTPUT}
 
-      - name: Build and push
+      - name: Build and push distroless
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: true
@@ -35,5 +35,36 @@ jobs:
           tags: >
             ghcr.io/${{ steps.vars.outputs.lowercase_repository }}:latest,
             ghcr.io/${{ steps.vars.outputs.lowercase_repository }}:${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-alpine:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set variables
+        id: vars
+        run: |
+          repository=${{ github.repository }}
+          echo "lowercase_repository=${repository,,}" >> ${GITHUB_OUTPUT}
+
+      - name: Build and push alpine
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          file: Dockerfile.alpine
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: >
+            ghcr.io/${{ steps.vars.outputs.lowercase_repository }}:latest-alpine,
+            ghcr.io/${{ steps.vars.outputs.lowercase_repository }}:${{ github.ref_name }}-alpine
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,11 +9,9 @@ RUN cp /app/target/${RUST_MUSL_CROSS_TARGET}/release/rustic-exporter /app/rustic
 
 FROM --platform=$TARGETPLATFORM alpine:3.23
 RUN apk add --no-cache \
-    ca-certificates \
-    openssh-client \
-    && adduser -D -u 65532 nonroot
+  ca-certificates \
+  openssh-client
 
-COPY --from=build --chown=nonroot:nonroot /app/rustic-exporter /rustic-exporter
+COPY --from=build /app/rustic-exporter /rustic-exporter
 
-USER nonroot
 ENTRYPOINT [ "/rustic-exporter" ]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,19 @@
+FROM --platform=$BUILDPLATFORM messense/rust-musl-cross:aarch64-musl AS build_arm64
+FROM --platform=$BUILDPLATFORM messense/rust-musl-cross:x86_64-musl AS build_amd64
+
+FROM --platform=$BUILDPLATFORM build_$TARGETARCH AS build
+WORKDIR /app
+COPY . .
+RUN cargo build -r --target $RUST_MUSL_CROSS_TARGET
+RUN cp /app/target/${RUST_MUSL_CROSS_TARGET}/release/rustic-exporter /app/rustic-exporter
+
+FROM --platform=$TARGETPLATFORM alpine:3.23
+RUN apk add --no-cache \
+    ca-certificates \
+    openssh-client \
+    && adduser -D -u 65532 nonroot
+
+COPY --from=build --chown=nonroot:nonroot /app/rustic-exporter /rustic-exporter
+
+USER nonroot
+ENTRYPOINT [ "/rustic-exporter" ]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Originally I would like to craft a restic-exporter supporting multiple backup re
 
 The backup client should use `restic >= v0.17`, or metrics like `rustic_snapshot_size_bytes` will be dropped.
 
+### Docker Images
+
+Two image variants are available:
+
+- **Distroless** (default): `ghcr.io/timtorchen/rustic-exporter:latest`
+- **Alpine**: `ghcr.io/timtorchen/rustic-exporter:latest-alpine`
+  - Includes openssh-client for SSH-based remote repositories
+
+Both variants support `linux/amd64` and `linux/arm64` platforms.
+
 ### Usage
 
 #### Command line

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -49,3 +49,16 @@ tasks:
           docker buildx build . \
           --tag rustic-exporter:local \
           --load
+
+  docker:build:alpine:
+    cmds:
+      - |
+          docker buildx build . \
+          --file Dockerfile.alpine \
+          --platform=linux/amd64,linux/arm64 \
+          --tag rustic-exporter:local-alpine
+      - |
+          docker buildx build . \
+          --file Dockerfile.alpine \
+          --tag rustic-exporter:local-alpine \
+          --load


### PR DESCRIPTION
Adds an Alpine docker image. Useful for use with sftp backed repos, since the distroless image does not include an ssh client and has no easy way of adding.