### PR TITLE
feat: retry dropped connections, eg. sftp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
+checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
 dependencies = [
  "dtoa",
  "itoa",

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -93,7 +93,7 @@ impl RusticCollector {
         tokio::spawn(async move {
             Self::set_repository(collector_task.clone()).await;
             loop {
-                if let Err(_) = Self::update_snapshot(collector_task.clone()).await {
+                if Self::update_snapshot(collector_task.clone()).await.is_err() {
                     Self::set_repository(collector_task.clone()).await;
                 }
                 tokio::time::sleep(Duration::from_secs(collector_task.interval)).await;

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -15,6 +15,27 @@ use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
 #[derive(Debug)]
+enum UpdateError {
+    RepositoryNotReady,
+    SnapshotUpdateFailed,
+    ConnectionLost { previous_count: usize },
+}
+
+impl std::fmt::Display for UpdateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UpdateError::RepositoryNotReady => write!(f, "repository not ready"),
+            UpdateError::SnapshotUpdateFailed => write!(f, "snapshot update failed"),
+            UpdateError::ConnectionLost { previous_count } => {
+                write!(f, "connection lost (snapshots: {} → 0)", previous_count)
+            }
+        }
+    }
+}
+
+impl std::error::Error for UpdateError {}
+
+#[derive(Debug)]
 pub struct RusticCollector {
     backup: Backup,
     interval: u64,
@@ -72,7 +93,9 @@ impl RusticCollector {
         tokio::spawn(async move {
             Self::set_repository(collector_task.clone()).await;
             loop {
-                Self::update_snapshot(collector_task.clone()).await;
+                if let Err(_) = Self::update_snapshot(collector_task.clone()).await {
+                    Self::set_repository(collector_task.clone()).await;
+                }
                 tokio::time::sleep(Duration::from_secs(collector_task.interval)).await;
             }
         });
@@ -116,39 +139,71 @@ impl RusticCollector {
         info!("Repository is ready, repository: {}", self.backup.name);
     }
 
-    async fn update_snapshot(self: Arc<Self>) {
+    async fn update_snapshot(self: Arc<Self>) -> Result<(), UpdateError> {
         debug!("Updating metrics, repository: {}", self.backup.name);
 
         let collector = self.clone();
-        let update_result = tokio::task::spawn_blocking(move || {
+        let update_task = tokio::task::spawn_blocking(move || -> Result<(), UpdateError> {
             let repo_guard = collector.repository.load();
-            let repo = match repo_guard.as_ref() {
-                Some(repo) => repo,
-                None => return,
-            };
+            let repo = repo_guard
+                .as_ref()
+                .as_ref()
+                .ok_or(UpdateError::RepositoryNotReady)?;
 
-            let snapshots_result = repo.update_all_snapshots(collector.snapshots.load().to_vec());
-            match snapshots_result {
-                Ok(snapshots) => {
-                    collector.snapshots.swap(Arc::new(snapshots));
-                }
-                Err(_err) => {
-                    error!(
-                        "Unable to update snapshot, repository: {}",
-                        collector.backup.name
-                    );
-                }
-            };
-        })
-        .await;
+            let previous_snapshots = collector.snapshots.load();
+            let snapshots = repo
+                .update_all_snapshots(previous_snapshots.to_vec())
+                .map_err(|_| UpdateError::SnapshotUpdateFailed)?;
 
-        match update_result {
-            Ok(()) => debug!(
-                "Successfully updated metrics, repository: {}",
-                self.backup.name
-            ),
-            Err(_err) => error!("Failed to update metrics, repository: {}", self.backup.name),
-        }
+            // Defensive check: if we previously had snapshots but now have none,
+            // this is suspicious and likely indicates a connection failure
+            if !previous_snapshots.is_empty() && snapshots.is_empty() {
+                return Err(UpdateError::ConnectionLost {
+                    previous_count: previous_snapshots.len(),
+                });
+            }
+
+            collector.snapshots.swap(Arc::new(snapshots));
+            Ok(())
+        });
+
+        // Add timeout to prevent indefinite hangs on dead connections
+        let timeout_duration = Duration::from_secs(60);
+
+        let task_result = tokio::time::timeout(timeout_duration, update_task)
+            .await
+            .map_err(|_| {
+                error!(
+                    "Update timed out after {}s, reconnecting: {}",
+                    timeout_duration.as_secs(),
+                    self.backup.name
+                );
+                UpdateError::SnapshotUpdateFailed
+            })?;
+
+        let update_result = task_result.map_err(|_| {
+            error!("Update task panicked, repository: {}", self.backup.name);
+            UpdateError::SnapshotUpdateFailed
+        })?;
+
+        update_result.map_err(|err| {
+            // Log based on error severity
+            match &err {
+                UpdateError::ConnectionLost { .. } => {
+                    warn!("{}, reconnecting: {}", err, self.backup.name);
+                }
+                _ => {
+                    error!("{}, repository: {}", err, self.backup.name);
+                }
+            }
+            err
+        })?;
+
+        debug!(
+            "Successfully updated metrics, repository: {}",
+            self.backup.name
+        );
+        Ok(())
     }
 }
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -19,6 +19,7 @@ enum UpdateError {
     RepositoryNotReady,
     SnapshotUpdateFailed,
     ConnectionLost { previous_count: usize },
+    Timeout,
 }
 
 impl std::fmt::Display for UpdateError {
@@ -29,6 +30,7 @@ impl std::fmt::Display for UpdateError {
             UpdateError::ConnectionLost { previous_count } => {
                 write!(f, "connection lost (snapshots: {} → 0)", previous_count)
             }
+            UpdateError::Timeout => write!(f, "update timed out"),
         }
     }
 }
@@ -172,32 +174,24 @@ impl RusticCollector {
 
         let task_result = tokio::time::timeout(timeout_duration, update_task)
             .await
-            .map_err(|_| {
-                error!(
-                    "Update timed out after {}s, reconnecting: {}",
-                    timeout_duration.as_secs(),
-                    self.backup.name
-                );
-                UpdateError::SnapshotUpdateFailed
-            })?;
+            .map_err(|_| UpdateError::Timeout)?;
 
         let update_result = task_result.map_err(|_| {
             error!("Update task panicked, repository: {}", self.backup.name);
             UpdateError::SnapshotUpdateFailed
         })?;
 
-        update_result.map_err(|err| {
-            // Log based on error severity
+        if let Some(err) = update_result.err() {
             match &err {
-                UpdateError::ConnectionLost { .. } => {
+                UpdateError::ConnectionLost { .. } | UpdateError::Timeout => {
                     warn!("{}, reconnecting: {}", err, self.backup.name);
                 }
                 _ => {
                     error!("{}, repository: {}", err, self.backup.name);
                 }
             }
-            err
-        })?;
+            return Err(err);
+        }
 
         debug!(
             "Successfully updated metrics, repository: {}",


### PR DESCRIPTION
I found that the sftp backend often loses connection. One way to detect this is if number of snapshots goes from some number n -> 0, which indicates we probably have some issue.

This PR tries to reconnect to a repo when this happens. Have been running this for a week and solves the issue. Example from my logs:

```
2026-04-15T18:58:48.103522Z  INFO rustic_exporter: Using configuration file: /local/config.toml
2026-04-15T18:58:48.112766Z  INFO rustic_exporter: Registering repositroy: hermes-cloud-backups-hermes-files
2026-04-15T18:58:48.112792Z  INFO rustic_exporter: Registering repositroy: orpheus-cloud-backups-orpheus-files
2026-04-15T18:58:48.112871Z  INFO rustic_exporter: Registering repositroy: zeus-cloud-backups-immich
2026-04-15T18:58:48.112931Z  INFO rustic_exporter: Registering repositroy: zeus-forgejo-cloud-backups-forgejo
2026-04-15T18:58:48.113011Z  INFO rustic_exporter: Registering repositroy: postgres
2026-04-15T18:58:48.114059Z  INFO rustic_exporter: Start server on http://<ip>:6780
2026-04-15T18:58:50.022581Z  INFO rustic_exporter::collector: Repository is ready, repository: zeus-forgejo-cloud-backups-forgejo
2026-04-15T18:58:50.316918Z  INFO rustic_exporter::collector: Repository is ready, repository: orpheus-cloud-backups-orpheus-files
2026-04-15T18:58:50.512801Z  INFO rustic_exporter::collector: Repository is ready, repository: postgres
2026-04-15T18:58:50.670339Z  INFO rustic_exporter::collector: Repository is ready, repository: hermes-cloud-backups-hermes-files
2026-04-15T18:58:51.065031Z  INFO rustic_exporter::collector: Repository is ready, repository: zeus-cloud-backups-immich
2026-04-15T19:34:29.110848Z  WARN rustic_exporter::collector: connection lost (snapshots: 32 → 0), reconnecting: zeus-forgejo-cloud-backups-forgejo
2026-04-15T19:34:29.171381Z  WARN rustic_exporter::collector: connection lost (snapshots: 29 → 0), reconnecting: zeus-cloud-backups-immich
2026-04-15T19:34:29.292502Z  WARN rustic_exporter::collector: connection lost (snapshots: 25 → 0), reconnecting: hermes-cloud-backups-hermes-files
2026-04-15T19:34:29.343525Z  WARN rustic_exporter::collector: connection lost (snapshots: 6 → 0), reconnecting: postgres
2026-04-15T19:34:29.900885Z  INFO rustic_exporter::collector: Repository is ready, repository: zeus-forgejo-cloud-backups-forgejo
2026-04-15T19:34:29.957825Z  INFO rustic_exporter::collector: Repository is ready, repository: zeus-cloud-backups-immich
2026-04-15T19:34:30.448467Z  INFO rustic_exporter::collector: Repository is ready, repository: postgres
2026-04-15T19:34:30.545021Z  INFO rustic_exporter::collector: Repository is ready, repository: hermes-cloud-backups-hermes-files
```

Interacting or getting any type of good feedback from the opendal sftp backend is currently impossible, see [ref](https://github.com/rustic-rs/rustic/issues/1488).