### PR TITLE
refactor: align log printing logic

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,10 +12,6 @@ pub(crate) struct Args {
     #[arg(long, value_name = "LOG_LEVEL", default_value = "info")]
     pub(crate) log_level: String,
 
-    /// Show debug logs of all dependencies
-    #[arg(long, short, value_name = "VERBOSE")]
-    pub(crate) verbose: bool,
-
     /// Path to the configuration file
     #[arg(long, short, long = "config", value_name = "CONFIG")]
     pub(crate) config_path: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ pub(crate) struct Args {
     #[arg(long, value_name = "LOG_LEVEL", default_value = "info")]
     pub(crate) log_level: String,
 
-    /// Show logs of all dependents
+    /// Show debug logs of all dependents
     #[arg(long, short, value_name = "VERBOSE")]
     pub(crate) verbose: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ pub(crate) struct Args {
     #[arg(long, value_name = "LOG_LEVEL", default_value = "info")]
     pub(crate) log_level: String,
 
-    /// Show debug logs of all dependents
+    /// Show debug logs of all dependencies
     #[arg(long, short, value_name = "VERBOSE")]
     pub(crate) verbose: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,13 +52,7 @@ async fn main() {
 
     let filter = match EnvFilter::builder().try_from_env() {
         Ok(f) => f,
-        Err(_) => {
-            if args.verbose {
-                EnvFilter::new("debug")
-            } else {
-                EnvFilter::new(format!("warn,rustic_exporter={}", args.log_level))
-            }
-        }
+        Err(_) => EnvFilter::new(format!("warn,rustic_exporter={}", args.log_level)),
     };
     let is_terminal = stdout().is_terminal();
     tracing_subscriber::fmt()

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,11 @@ use clap::Parser;
 use core::panic;
 use prometheus_client::{encoding::text::encode, registry::Registry};
 use regex::Regex;
-use std::io::stdout;
-use std::{env, fs, io::IsTerminal, sync::Arc};
+use std::{
+    env, fs,
+    io::{stdout, IsTerminal},
+    sync::Arc,
+};
 use tokio::signal;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,11 @@ use clap::Parser;
 use core::panic;
 use prometheus_client::{encoding::text::encode, registry::Registry};
 use regex::Regex;
-use std::{env, fs, sync::Arc};
+use std::io::stdout;
+use std::{env, fs, io::IsTerminal, sync::Arc};
 use tokio::signal;
 use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
 
 async fn metrics_handler(State(registry): State<Arc<Registry>>) -> impl IntoResponse {
     let mut buffer = String::new();
@@ -45,14 +47,21 @@ fn replace_with_env_vars(input: &str) -> String {
 async fn main() {
     let args = cli::Args::parse();
 
-    // log level
-    if args.verbose {
-        tracing_subscriber::fmt().init();
-    } else {
-        let filter =
-            tracing_subscriber::EnvFilter::new(format!("rustic_exporter={}", args.log_level));
-        tracing_subscriber::fmt().with_env_filter(filter).init();
-    }
+    let filter = match EnvFilter::builder().try_from_env() {
+        Ok(f) => f,
+        Err(_) => {
+            if args.verbose {
+                EnvFilter::new("debug")
+            } else {
+                EnvFilter::new(format!("warn,rustic_exporter={}", args.log_level))
+            }
+        }
+    };
+    let is_terminal = stdout().is_terminal();
+    tracing_subscriber::fmt()
+        .with_ansi(is_terminal)
+        .with_env_filter(filter)
+        .init();
 
     let config_path = args.config_path;
     let mut file_content = match fs::read_to_string(config_path.clone()) {


### PR DESCRIPTION
The current argument is a little confusing, this PR aligns the log printing logic.

### Changes
1. (breaking) remove the `--verbose` argument
2. update the log configuration behavior:
   - use `RUST_LOG` if provided (full override)
   - otherwise use to `warn,rustic_exporter=<log_level>`
3. Disable color in non TTY