### PR TITLE
refactor: retry setting repository 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
  "rustic_backend",
  "rustic_core",
  "serde",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2467,7 +2467,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2907,7 +2907,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2948,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3438,14 +3438,14 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
@@ -4043,7 +4043,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ regex = "1.11.1"
 arc-swap = "1.8.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+thiserror = "2"
 
 [profile.release]
 panic = "unwind"

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -144,6 +144,7 @@ impl RusticCollector {
                     .as_ref()
                     .ok_or(CollectorError::RepositoryNotReady)?;
 
+                // TODO: find a way to differentiate between snapshots cleared intentionally and repository corrpution
                 let snapshots = repo
                     .update_all_snapshots(collector.snapshots.load().to_vec())
                     .map_err(|_| CollectorError::SnapshotUpdateFailed)?;

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -12,7 +12,16 @@ use rustic_core::{
 };
 use std::sync::{atomic::AtomicU64, Arc};
 use std::time::Duration;
+use thiserror::Error;
 use tracing::{debug, error, info, warn};
+
+#[derive(Debug, Error)]
+pub enum CollectorError {
+    #[error("repository is not ready")]
+    RepositoryNotReady,
+    #[error("snapshot update failed")]
+    SnapshotUpdateFailed,
+}
 
 #[derive(Debug)]
 pub struct RusticCollector {
@@ -68,87 +77,86 @@ impl RusticCollector {
             snapshots: ArcSwap::new(Arc::new(Vec::new())),
         });
 
-        let collector_task = collector.clone();
-        tokio::spawn(async move {
-            Self::set_repository(collector_task.clone()).await;
-            loop {
-                Self::update_snapshot(collector_task.clone()).await;
-                tokio::time::sleep(Duration::from_secs(collector_task.interval)).await;
+        tokio::spawn({
+            let collector = collector.clone();
+            async move {
+                loop {
+                    let repo_result = Self::set_repository(collector.clone()).await;
+                    if repo_result.is_ok() {
+                        // successfully set the repository, looply update snapshots
+                        loop {
+                            let snapshots_result = Self::update_snapshots(collector.clone()).await;
+                            if matches!(snapshots_result, Err(CollectorError::RepositoryNotReady)) {
+                                // repository become not ready somehow, break the loop and start over
+                                break;
+                            }
+                            tokio::time::sleep(Duration::from_secs(collector.interval)).await;
+                        }
+                    } else {
+                        // failed to set the repository, wait and start over
+                        error!(
+                            repository = collector.backup.name,
+                            "failed to set the repostiroy"
+                        );
+                        tokio::time::sleep(Duration::from_secs(collector.interval)).await;
+                    }
+                }
             }
         });
         collector
     }
 
-    async fn set_repository(self: Arc<Self>) {
+    async fn set_repository(self: Arc<Self>) -> Result<(), CollectorError> {
+        debug!(repository = self.backup.name, "setting repository");
         let opts = match (&self.backup.password, &self.backup.password_file) {
             (Some(password), _) => RepositoryOptions::default().password(password),
             (_, Some(password_file)) => RepositoryOptions::default().password_file(password_file),
-            _ => panic!("Either password or password_file must be set"),
+            _ => panic!("either password or password_file must be set"),
         };
 
-        let backend_result = BackendOptions::default()
+        let backend = BackendOptions::default()
             .repository(&self.backup.repository)
             .options(self.backup.options.clone())
-            .to_backends();
+            .to_backends()
+            .map_err(|_| CollectorError::RepositoryNotReady)?;
 
-        let backend = match backend_result {
-            Ok(backend) => backend,
-            Err(_) => {
-                error!("Unable to set the backend, repository {}", self.backup.name);
-                return;
-            }
-        };
-
-        let repository_result = tokio::task::spawn_blocking(move || {
+        let repository = tokio::task::spawn_blocking(move || {
             Repository::new(&opts, &backend).and_then(|repo| repo.open())
         })
-        .await;
-
-        let repository = match repository_result {
-            Ok(Ok(repo)) => repo,
-            _ => {
-                error!("Unable to open the repository: {}", self.backup.name);
-                return;
-            }
-        };
+        .await
+        .map_err(|_| CollectorError::RepositoryNotReady)?
+        .map_err(|_| CollectorError::RepositoryNotReady)?;
 
         self.repository.store(Arc::new(Some(repository)));
-        info!("Repository is ready, repository: {}", self.backup.name);
+        info!(repository = self.backup.name, "repository is ready");
+        Ok(())
     }
 
-    async fn update_snapshot(self: Arc<Self>) {
-        debug!("Updating metrics, repository: {}", self.backup.name);
+    async fn update_snapshots(self: Arc<Self>) -> Result<(), CollectorError> {
+        debug!(repository = self.backup.name, "updating snapshots");
+        let collector: Arc<RusticCollector> = self.clone();
 
-        let collector = self.clone();
-        let update_result = tokio::task::spawn_blocking(move || {
-            let repo_guard = collector.repository.load();
-            let repo = match repo_guard.as_ref() {
-                Some(repo) => repo,
-                None => return,
-            };
+        let snpashots = tokio::task::spawn_blocking({
+            move || -> Result<Vec<SnapshotFile>, CollectorError> {
+                let repo_guard = collector.repository.load();
+                let repo = repo_guard
+                    .as_ref()
+                    .as_ref()
+                    .ok_or(CollectorError::RepositoryNotReady)?;
 
-            let snapshots_result = repo.update_all_snapshots(collector.snapshots.load().to_vec());
-            match snapshots_result {
-                Ok(snapshots) => {
-                    collector.snapshots.swap(Arc::new(snapshots));
-                }
-                Err(_err) => {
-                    error!(
-                        "Unable to update snapshot, repository: {}",
-                        collector.backup.name
-                    );
-                }
-            };
+                let snapshots = repo
+                    .update_all_snapshots(collector.snapshots.load().to_vec())
+                    .map_err(|_| CollectorError::SnapshotUpdateFailed)?;
+                Ok(snapshots)
+            }
         })
-        .await;
+        .await
+        .map_err(|_| CollectorError::SnapshotUpdateFailed)?
+        .map_err(|_| CollectorError::SnapshotUpdateFailed)?;
 
-        match update_result {
-            Ok(()) => debug!(
-                "Successfully updated metrics, repository: {}",
-                self.backup.name
-            ),
-            Err(_err) => error!("Failed to update metrics, repository: {}", self.backup.name),
-        }
+        self.snapshots.swap(Arc::new(snpashots));
+        info!(repository = %self.backup.name, "snapshots updated");
+        Ok(())
     }
 }
 
@@ -158,10 +166,7 @@ impl Collector for RusticCollector {
         let repo = match repo_guard.as_ref() {
             Some(repo) => repo,
             None => {
-                warn!(
-                    "Repository is not ready yet, repository: {}",
-                    self.backup.name
-                );
+                warn!(repository = self.backup.name, "repository is not ready yet",);
                 return Ok(());
             }
         };
@@ -220,9 +225,9 @@ impl Collector for RusticCollector {
             // skip current iteration if snapshot summary having no data
             if snapshot.summary.is_none() {
                 warn!(
-                    "Snapshot summary has no data, repository: {}, snapshot_id: {} ",
-                    self.backup.name,
-                    snapshot.id.to_string()
+                    repository = self.backup.name,
+                    snapshot_id = snapshot.id.to_string(),
+                    "snapshot summary has no data",
                 );
                 continue;
             }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -96,7 +96,7 @@ impl RusticCollector {
                         // failed to set the repository, wait and start over
                         error!(
                             repository = collector.backup.name,
-                            "failed to set the repostiroy"
+                            "failed to set the repository"
                         );
                         tokio::time::sleep(Duration::from_secs(collector.interval)).await;
                     }
@@ -136,7 +136,7 @@ impl RusticCollector {
         debug!(repository = self.backup.name, "updating snapshots");
         let collector: Arc<RusticCollector> = self.clone();
 
-        let snpashots = tokio::task::spawn_blocking({
+        let snapshots = tokio::task::spawn_blocking({
             move || -> Result<Vec<SnapshotFile>, CollectorError> {
                 let repo_guard = collector.repository.load();
                 let repo = repo_guard
@@ -151,10 +151,9 @@ impl RusticCollector {
             }
         })
         .await
-        .map_err(|_| CollectorError::SnapshotUpdateFailed)?
-        .map_err(|_| CollectorError::SnapshotUpdateFailed)?;
+        .map_err(|_| CollectorError::SnapshotUpdateFailed)??;
 
-        self.snapshots.swap(Arc::new(snpashots));
+        self.snapshots.swap(Arc::new(snapshots));
         info!(repository = %self.backup.name, "snapshots updated");
         Ok(())
     }


### PR DESCRIPTION
### Description

This PR intoduces the retry logic in setting repository:
```mermaid
flowchart TD
    A[Outer loop] --> B["set_repository()"]

    B --> C{repository setting OK?}
    C -- Yes --> D[Snapshot update loop]
    C -- No --> E[sleep]
    E --> A

    D --> G["update_snapshots()"]
    G --> H{repository not ready?}
    H -- Yes --> A
    H -- No --> I[sleep]
    I --> G
```


with some minor changes:
- Add `thiserror` dependency and introduce `CollectorError`
- Follows parametered log in `tracing`, and standardize log messages to lowercase
- Move error logging to `RusticCollector::new`