### PR TITLE
mitigate: add defensive check for empty snapshot result

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Options:
   -i, --interval <INTERVAL>    Metrics collection frequency in seconds [default: 300]
       --log-level <LOG_LEVEL>  Log level: debug, info, warn, error [default: info]
   -c, --config <CONFIG>        Path to the configuration file
-      --defensive              Enable defensive check for snapshots
+      --defensive              Enable defensive check to detect unexpected empty snapshots
       --host <HOST>            Server host [default: 0.0.0.0]
       --port <PORT>            Server port [default: 8080]
   -h, --help                   Print help

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Usage: rustic-exporter [OPTIONS] --config <CONFIG>
 Options:
   -i, --interval <INTERVAL>    Metrics collection frequency in seconds [default: 300]
       --log-level <LOG_LEVEL>  Log level: debug, info, warn, error [default: info]
-  -v, --verbose                Show logs of all dependents
   -c, --config <CONFIG>        Path to the configuration file
+      --defensive              Enable defensive check for snapshots
       --host <HOST>            Server host [default: 0.0.0.0]
       --port <PORT>            Server port [default: 8080]
   -h, --help                   Print help

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,10 @@ pub(crate) struct Args {
     #[arg(long, short, long = "config", value_name = "CONFIG")]
     pub(crate) config_path: String,
 
+    /// Enable defensive check for snapshots
+    #[arg(long)]
+    pub(crate) defensive: bool,
+
     /// Server host
     #[arg(long, value_name = "HOST", default_value = "0.0.0.0")]
     pub(crate) host: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@ pub(crate) struct Args {
     #[arg(long, short, long = "config", value_name = "CONFIG")]
     pub(crate) config_path: String,
 
-    /// Enable defensive check for snapshots
+    /// Enable defensive check to detect unexpected empty snapshots
     #[arg(long)]
     pub(crate) defensive: bool,
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -19,14 +19,17 @@ use tracing::{debug, error, info, warn};
 pub enum CollectorError {
     #[error("repository is not ready")]
     RepositoryNotReady,
-    #[error("snapshot update failed")]
+    #[error("snapshots update failed")]
     SnapshotUpdateFailed,
+    #[error("snapshots became empty unexpectedly")]
+    SnapshotUnexpectedlyEmpty,
 }
 
 #[derive(Debug)]
 pub struct RusticCollector {
     backup: Backup,
     interval: u64,
+    defensive: bool,
     repository: ArcSwap<Option<Repository<NoProgressBars, OpenStatus>>>,
     snapshots: ArcSwap<Vec<SnapshotFile>>,
 }
@@ -69,10 +72,11 @@ struct Metrics {
 }
 
 impl RusticCollector {
-    pub fn new(backup: Backup, interval: u64) -> Arc<Self> {
+    pub fn new(backup: Backup, interval: u64, defensive: bool) -> Arc<Self> {
         let collector = Arc::new(Self {
             backup,
             interval,
+            defensive,
             repository: ArcSwap::new(Arc::new(None)),
             snapshots: ArcSwap::new(Arc::new(Vec::new())),
         });
@@ -86,9 +90,15 @@ impl RusticCollector {
                         // successfully set the repository, looply update snapshots
                         loop {
                             let snapshots_result = Self::update_snapshots(collector.clone()).await;
-                            if matches!(snapshots_result, Err(CollectorError::RepositoryNotReady)) {
-                                // repository become not ready somehow, break the loop and start over
-                                break;
+                            match snapshots_result {
+                                Ok(_) => {}
+                                Err(err) => {
+                                    error!(%err);
+                                    if matches!(err, CollectorError::RepositoryNotReady) {
+                                        // repository become not ready somehow, break the loop and start over
+                                        break;
+                                    }
+                                }
                             }
                             tokio::time::sleep(Duration::from_secs(collector.interval)).await;
                         }
@@ -153,6 +163,16 @@ impl RusticCollector {
         })
         .await
         .map_err(|_| CollectorError::SnapshotUpdateFailed)??;
+
+        // Defensive check: if we previously had snapshots but now have none,
+        // this is suspicious and likely indicates a connection failure, or a repository corruption.
+        // In this case, skips updating snapshots.
+        if self.defensive {
+            let previous_snapshots = self.snapshots.load();
+            if !previous_snapshots.is_empty() && snapshots.is_empty() {
+                return Err(CollectorError::SnapshotUnexpectedlyEmpty);
+            }
+        }
 
         self.snapshots.swap(Arc::new(snapshots));
         info!(repository = %self.backup.name, "snapshots updated");

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -93,7 +93,7 @@ impl RusticCollector {
                             match snapshots_result {
                                 Ok(_) => {}
                                 Err(err) => {
-                                    error!(%err);
+                                    error!(repository = %collector.backup.name, %err);
                                     if matches!(err, CollectorError::RepositoryNotReady) {
                                         // repository become not ready somehow, break the loop and start over
                                         break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,10 +79,15 @@ async fn main() {
         }
     };
 
+    let defensive = args.defensive;
+    if defensive {
+        info!("Snapshots defensive check is enabled")
+    }
+
     let mut registry = Registry::default();
     for backup in config.backups {
         info!("Registering repositroy: {}", backup.name);
-        let collector = collector::RusticCollector::new(backup, args.interval);
+        let collector = collector::RusticCollector::new(backup, args.interval, defensive);
         registry.register_collector(Box::new(collector));
     }
     let addr = format!("{}:{}", args.host, args.port);


### PR DESCRIPTION
This PR adds a new `--defensive` flag to detect unexpected empty snapshots.
Originally proposed in PR https://github.com/timtorChen/rustic-exporter/pull/118.