### PR TITLE
refactor: improve logging 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,6 +3847,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3856,12 +3866,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ toml = "1.0.0"
 regex = "1.11.1"
 arc-swap = "1.8.2"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "2"
 
 [profile.release]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 /// Rustic exporter
 #[derive(Parser)]
@@ -8,9 +8,13 @@ pub(crate) struct Args {
     #[arg(long, short, value_name = "INTERVAL", default_value = "300")]
     pub(crate) interval: u64,
 
-    /// Log level: debug, info, warn, error
+    /// Log level
     #[arg(long, value_name = "LOG_LEVEL", default_value = "info")]
-    pub(crate) log_level: String,
+    pub(crate) log_level: LogLevel,
+
+    /// output format
+    #[arg(long, short, value_name = "OUTPUT", default_value = "text")]
+    pub(crate) output: OutputFormat,
 
     /// Path to the configuration file
     #[arg(long, short, long = "config", value_name = "CONFIG")]
@@ -27,4 +31,18 @@ pub(crate) struct Args {
     /// Server port
     #[arg(long, value_name = "PORT", default_value = "8080")]
     pub(crate) port: u16,
+}
+
+#[derive(ValueEnum, Clone)]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(ValueEnum, Clone)]
+pub enum OutputFormat {
+    Text,
+    Json,
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -124,7 +124,7 @@ impl RusticCollector {
     }
 
     async fn set_repository(self: Arc<Self>) -> Result<(), CollectorError> {
-        debug!(repository = self.backup.name, "setting repository");
+        debug!(repository = %self.backup.name, "setting repository");
 
         let repo_opts = RepositoryOptions::default();
         let backend = BackendOptions::default()
@@ -202,7 +202,7 @@ impl Collector for RusticCollector {
         let repo = match repo_guard.as_ref() {
             Some(repo) => repo,
             None => {
-                warn!(repository = self.backup.name, "repository is not ready yet",);
+                warn!(repository = %self.backup.name, "repository is not ready yet",);
                 return Ok(());
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,29 +79,29 @@ async fn main() {
     let mut file_content = match fs::read_to_string(config_path.clone()) {
         Ok(c) => c,
         Err(e) => {
-            error!("Unable to read the configuration file");
-            panic!("Error: {}", e);
+            error!("unable to read the configuration file");
+            panic!("error: {}", e);
         }
     };
-    info!("Using configuration file: {}", config_path);
+    info!("using configuration file: {}", config_path);
 
     file_content = replace_with_env_vars(&file_content);
     let config: Config = match toml::from_str(&file_content) {
         Ok(c) => c,
         Err(e) => {
-            error!("Invaid toml file");
-            panic!("Error: {}", e);
+            error!("invaid toml file");
+            panic!("error: {}", e);
         }
     };
 
     let defensive = args.defensive;
     if defensive {
-        info!("Snapshots defensive check is enabled")
+        info!("snapshots defensive check is enabled")
     }
 
     let mut registry = Registry::default();
     for backup in config.backups {
-        info!("Registering repositroy: {}", backup.name);
+        info!("registering repositroy: {}", backup.name);
         let collector = collector::RusticCollector::new(backup, args.interval, defensive);
         registry.register_collector(Box::new(collector));
     }
@@ -109,8 +109,8 @@ async fn main() {
     let listener = match tokio::net::TcpListener::bind(addr.clone()).await {
         Ok(c) => c,
         Err(e) => {
-            error!("Cannot listen on {}", addr);
-            panic!("Error: {}", e);
+            error!("cannot listen on {}", addr);
+            panic!("error: {}", e);
         }
     };
     let shared_registry = Arc::new(registry);
@@ -118,7 +118,7 @@ async fn main() {
         .route("/metrics", get(metrics_handler))
         .with_state(shared_registry);
 
-    info!("Start server on http://{addr}");
+    info!("start server on http://{addr}");
     let server = axum::serve(listener, router);
     let server_result = if cfg!(debug_assertions) {
         server.await
@@ -129,8 +129,8 @@ async fn main() {
     match server_result {
         Ok(_) => {}
         Err(e) => {
-            error!("Failed to start server");
-            panic!("Error: {}", e);
+            error!("failed to start server");
+            panic!("error: {}", e);
         }
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ use axum::{
 };
 
 use clap::{Parser, ValueEnum};
-use core::panic;
 use prometheus_client::{encoding::text::encode, registry::Registry};
 use regex::Regex;
 use std::{
@@ -79,18 +78,18 @@ async fn main() {
     let mut file_content = match fs::read_to_string(config_path.clone()) {
         Ok(c) => c,
         Err(e) => {
-            error!("unable to read the configuration file");
-            panic!("error: {}", e);
+            error!(error = %e, "unable to read the configuration file");
+            std::process::exit(1)
         }
     };
-    info!("using configuration file: {}", config_path);
+    info!("using configuration file: {config_path}");
 
     file_content = replace_with_env_vars(&file_content);
     let config: Config = match toml::from_str(&file_content) {
         Ok(c) => c,
         Err(e) => {
-            error!("invaid toml file");
-            panic!("error: {}", e);
+            error!(error = %e, "invaid toml file");
+            std::process::exit(1)
         }
     };
 
@@ -101,7 +100,7 @@ async fn main() {
 
     let mut registry = Registry::default();
     for backup in config.backups {
-        info!("registering repositroy: {}", backup.name);
+        info!(repository = %backup.name, "registering repositroy");
         let collector = collector::RusticCollector::new(backup, args.interval, defensive);
         registry.register_collector(Box::new(collector));
     }
@@ -109,8 +108,8 @@ async fn main() {
     let listener = match tokio::net::TcpListener::bind(addr.clone()).await {
         Ok(c) => c,
         Err(e) => {
-            error!("cannot listen on {}", addr);
-            panic!("error: {}", e);
+            error!(error = %e, "failed to bind listener {addr}");
+            std::process::exit(1)
         }
     };
     let shared_registry = Arc::new(registry);
@@ -129,8 +128,8 @@ async fn main() {
     match server_result {
         Ok(_) => {}
         Err(e) => {
-            error!("failed to start server");
-            panic!("error: {}", e);
+            error!(error = %e, "failed to start server");
+            std::process::exit(1)
         }
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use axum::{
     Router,
 };
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use core::panic;
 use prometheus_client::{encoding::text::encode, registry::Registry};
 use regex::Regex;
@@ -52,13 +52,28 @@ async fn main() {
 
     let filter = match EnvFilter::builder().try_from_env() {
         Ok(f) => f,
-        Err(_) => EnvFilter::new(format!("warn,rustic_exporter={}", args.log_level)),
+        Err(_) => EnvFilter::new(format!(
+            "warn,rustic_exporter={}",
+            args.log_level.to_possible_value().unwrap().get_name()
+        )),
     };
+
     let is_terminal = stdout().is_terminal();
-    tracing_subscriber::fmt()
-        .with_ansi(is_terminal)
-        .with_env_filter(filter)
-        .init();
+    match args.output {
+        cli::OutputFormat::Text => {
+            tracing_subscriber::fmt()
+                .with_ansi(is_terminal)
+                .with_env_filter(filter)
+                .init();
+        }
+        cli::OutputFormat::Json => {
+            tracing_subscriber::fmt()
+                .with_ansi(is_terminal)
+                .with_env_filter(filter)
+                .json()
+                .init();
+        }
+    }
 
     let config_path = args.config_path;
     let mut file_content = match fs::read_to_string(config_path.clone()) {


### PR DESCRIPTION
### Main changes
Adds a new option `--output` to control log output format.

### Minor changes
- Use ValueEnum to contrain option values.
- Update log message to start with lowercase.
- Replace `panic!` to `std::process::exit`.